### PR TITLE
Adjust cadastro connection string resolution

### DIFF
--- a/Oficina.ApiGateway/appsettings.json
+++ b/Oficina.ApiGateway/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "OficinaDb": "Host=oficina-postgres;Port=5432;Database=oficina_db;Username=oficina;Password=oficina123"
+    "OficinaDb": "Host=oficina-postgres;Port=5432;Database=oficina_db;Username=oficina;Password=oficina123",
+    "Default": "Host=oficina-postgres;Port=5432;Database=oficina_db;Username=oficina;Password=oficina123"
   },
 
   "Services": {

--- a/Oficina.Cadastro.Endpoints/OficinaModule.cs
+++ b/Oficina.Cadastro.Endpoints/OficinaModule.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Builder;
@@ -15,8 +16,17 @@ public static class OficinaModule
 {
     public static IServiceCollection AddCadastroModule(this IServiceCollection services, IConfiguration config)
     {
-        // Usa a mesma ConnectionString do gateway (Default), porém com DbContext do módulo
-        var cs = config.GetConnectionString("Default") ?? config["ConnectionStrings:Default"]!;
+        // Usa a ConnectionString específica do módulo (OficinaDb), com fallback para a padrão
+        var cs =
+            config.GetConnectionString("OficinaDb") ??
+            config["ConnectionStrings:OficinaDb"] ??
+            config.GetConnectionString("Default") ??
+            config["ConnectionStrings:Default"];
+
+        if (string.IsNullOrWhiteSpace(cs))
+        {
+            throw new InvalidOperationException("Connection string 'OficinaDb' was not found.");
+        }
         services.AddDbContext<CadastroDbContext>(opt => 
         opt.UseNpgsql(cs, x => x.MigrationsHistoryTable("__EFMigrationsHistory", CadastroDbContext.Schema)));
 


### PR DESCRIPTION
## Summary
- prioritize the OficinaDb connection string when configuring the cadastro module, falling back to Default only if necessary
- add a Default connection string entry in the API Gateway configuration for backward compatibility

## Testing
- Not run (environment missing dotnet SDK and Docker)


------
https://chatgpt.com/codex/tasks/task_e_68dadf1ff6b48327be2e278e9dc2d577