### PR TITLE
Fix Cadastro migrations to include service order tables

### DIFF
--- a/Oficina.Cadastro.Infrastructure/Migrations/20250919154952_InitialCreate.Designer.cs
+++ b/Oficina.Cadastro.Infrastructure/Migrations/20250919154952_InitialCreate.Designer.cs
@@ -25,18 +25,317 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("Oficina.Infrastructure.Persistence.Ping", b =>
+            modelBuilder.HasDefaultSchema("oficina");
+
+            modelBuilder.HasPostgresExtension("pgcrypto");
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.Cliente", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
 
-                    b.Property<DateTime>("CreatedAt")
+                    b.Property<DateTime>("CriadoEm")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Documento")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("Email")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)")
+                        .HasColumnName("email");
+
+                    b.Property<string>("Endereco")
+                        .HasMaxLength(300)
+                        .HasColumnType("character varying(300)");
+
+                    b.Property<string>("Nome")
+                        .IsRequired()
+                        .HasMaxLength(160)
+                        .HasColumnType("character varying(160)");
+
+                    b.Property<string>("Telefone")
+                        .IsRequired()
+                        .HasMaxLength(12)
+                        .HasColumnType("character varying(12)")
+                        .HasColumnName("telefone");
 
                     b.HasKey("Id");
 
-                    b.ToTable("pings", (string)null);
+                    b.HasIndex("Documento")
+                        .IsUnique();
+
+                    b.ToTable("clientes", "oficina");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.ItemOrdemServico", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
+
+                    b.Property<Guid>("OrdemServicoId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("PecaId")
+                        .HasColumnType("uuid");
+
+                    b.Property<decimal>("Preco")
+                        .HasColumnType("numeric(12,2)");
+
+                    b.Property<decimal>("Quantidade")
+                        .HasColumnType("numeric(12,3)");
+
+                    b.Property<Guid?>("ServicoId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Tipo")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("OrdemServicoId");
+
+                    b.HasIndex("PecaId");
+
+                    b.HasIndex("ServicoId");
+
+                    b.ToTable("itens_ordem_servico", "oficina");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.Moto", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
+
+                    b.Property<int>("Ano")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("ClienteId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Chassi")
+                        .HasMaxLength(30)
+                        .HasColumnType("character varying(30)");
+
+                    b.Property<int?>("KmAtual")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Marca")
+                        .IsRequired()
+                        .HasMaxLength(80)
+                        .HasColumnType("character varying(80)");
+
+                    b.Property<string>("Modelo")
+                        .IsRequired()
+                        .HasMaxLength(120)
+                        .HasColumnType("character varying(120)");
+
+                    b.Property<string>("Placa")
+                        .IsRequired()
+                        .HasMaxLength(8)
+                        .HasColumnType("character varying(8)")
+                        .HasColumnName("placa");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ClienteId");
+
+                    b.HasIndex("Placa")
+                        .IsUnique()
+                        .HasDatabaseName("IX_motos_placa");
+
+                    b.ToTable("motos", "oficina");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.OrdemServico", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
+
+                    b.Property<Guid>("ClienteId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("DataAbertura")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime?>("DataFechamento")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("MotoId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("ProfissionalId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)");
+
+                    b.Property<decimal>("Total")
+                        .HasColumnType("numeric(12,2)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ClienteId");
+
+                    b.HasIndex("MotoId");
+
+                    b.HasIndex("ProfissionalId");
+
+                    b.HasIndex("DataAbertura", "Status");
+
+                    b.ToTable("ordens_servico", "oficina");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.Peca", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
+
+                    b.Property<string>("Codigo")
+                        .IsRequired()
+                        .HasMaxLength(60)
+                        .HasColumnType("character varying(60)");
+
+                    b.Property<string>("Nome")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<decimal>("Preco")
+                        .HasColumnType("numeric(12,2)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Codigo")
+                        .IsUnique();
+
+                    b.ToTable("pecas", "oficina");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.Profissional", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
+
+                    b.Property<string>("Especialidade")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("Nome")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("profissionais", "oficina");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.Servico", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
+
+                    b.Property<string>("Nome")
+                        .IsRequired()
+                        .HasMaxLength(120)
+                        .HasColumnType("character varying(120)");
+
+                    b.Property<decimal>("PrecoBase")
+                        .HasColumnType("numeric(12,2)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("servicos", "oficina");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.ItemOrdemServico", b =>
+                {
+                    b.HasOne("Oficina.Cadastro.Domain.Entities.OrdemServico", "OrdemServico")
+                        .WithMany("Itens")
+                        .HasForeignKey("OrdemServicoId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Oficina.Cadastro.Domain.Entities.Peca", "Peca")
+                        .WithMany()
+                        .HasForeignKey("PecaId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("Oficina.Cadastro.Domain.Entities.Servico", "Servico")
+                        .WithMany()
+                        .HasForeignKey("ServicoId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.Navigation("OrdemServico");
+
+                    b.Navigation("Peca");
+
+                    b.Navigation("Servico");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.Moto", b =>
+                {
+                    b.HasOne("Oficina.Cadastro.Domain.Entities.Cliente", "Cliente")
+                        .WithMany()
+                        .HasForeignKey("ClienteId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Cliente");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.OrdemServico", b =>
+                {
+                    b.HasOne("Oficina.Cadastro.Domain.Entities.Cliente", "Cliente")
+                        .WithMany()
+                        .HasForeignKey("ClienteId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Oficina.Cadastro.Domain.Entities.Moto", "Moto")
+                        .WithMany()
+                        .HasForeignKey("MotoId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Oficina.Cadastro.Domain.Entities.Profissional", "Profissional")
+                        .WithMany()
+                        .HasForeignKey("ProfissionalId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Cliente");
+
+                    b.Navigation("Moto");
+
+                    b.Navigation("Profissional");
+                });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.OrdemServico", b =>
+                {
+                    b.Navigation("Itens");
                 });
 #pragma warning restore 612, 618
         }

--- a/Oficina.Cadastro.Infrastructure/Migrations/20250919154952_InitialCreate.cs
+++ b/Oficina.Cadastro.Infrastructure/Migrations/20250919154952_InitialCreate.cs
@@ -78,6 +78,46 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "ordens_servico",
+                schema: "oficina",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    MotoId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ClienteId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProfissionalId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    DataAbertura = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    DataFechamento = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Total = table.Column<decimal>(type: "numeric(12,2)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ordens_servico", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ordens_servico_clientes_ClienteId",
+                        column: x => x.ClienteId,
+                        principalSchema: "oficina",
+                        principalTable: "clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ordens_servico_motos_MotoId",
+                        column: x => x.MotoId,
+                        principalSchema: "oficina",
+                        principalTable: "motos",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ordens_servico_profissionais_ProfissionalId",
+                        column: x => x.ProfissionalId,
+                        principalSchema: "oficina",
+                        principalTable: "profissionais",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "motos",
                 schema: "oficina",
                 columns: table => new
@@ -99,6 +139,45 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
                         column: x => x.ClienteId,
                         principalSchema: "oficina",
                         principalTable: "clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "itens_ordem_servico",
+                schema: "oficina",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    OrdemServicoId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ServicoId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PecaId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Tipo = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Quantidade = table.Column<decimal>(type: "numeric(12,3)", nullable: false),
+                    Preco = table.Column<decimal>(type: "numeric(12,2)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_itens_ordem_servico", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_itens_ordem_servico_ordens_servico_OrdemServicoId",
+                        column: x => x.OrdemServicoId,
+                        principalSchema: "oficina",
+                        principalTable: "ordens_servico",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_itens_ordem_servico_pecas_PecaId",
+                        column: x => x.PecaId,
+                        principalSchema: "oficina",
+                        principalTable: "pecas",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_itens_ordem_servico_servicos_ServicoId",
+                        column: x => x.ServicoId,
+                        principalSchema: "oficina",
+                        principalTable: "servicos",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Restrict);
                 });
@@ -129,11 +208,61 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
                 table: "pecas",
                 column: "Codigo",
                 unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_itens_ordem_servico_OrdemServicoId",
+                schema: "oficina",
+                table: "itens_ordem_servico",
+                column: "OrdemServicoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_itens_ordem_servico_PecaId",
+                schema: "oficina",
+                table: "itens_ordem_servico",
+                column: "PecaId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_itens_ordem_servico_ServicoId",
+                schema: "oficina",
+                table: "itens_ordem_servico",
+                column: "ServicoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ordens_servico_ClienteId",
+                schema: "oficina",
+                table: "ordens_servico",
+                column: "ClienteId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ordens_servico_MotoId",
+                schema: "oficina",
+                table: "ordens_servico",
+                column: "MotoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ordens_servico_ProfissionalId",
+                schema: "oficina",
+                table: "ordens_servico",
+                column: "ProfissionalId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ordens_servico_DataAbertura_Status",
+                schema: "oficina",
+                table: "ordens_servico",
+                columns: new[] { "DataAbertura", "Status" });
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropTable(
+                name: "itens_ordem_servico",
+                schema: "oficina");
+
+            migrationBuilder.DropTable(
+                name: "ordens_servico",
+                schema: "oficina");
+
             migrationBuilder.DropTable(
                 name: "motos",
                 schema: "oficina");

--- a/Oficina.Cadastro.Infrastructure/Migrations/CadastroDbContextModelSnapshot.cs
+++ b/Oficina.Cadastro.Infrastructure/Migrations/CadastroDbContextModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.0")
+                .HasAnnotation("ProductVersion", "9.0.9")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             modelBuilder.HasDefaultSchema("oficina");
@@ -66,6 +66,44 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
                 b.ToTable("clientes", "oficina");
             });
 
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.ItemOrdemServico", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uuid")
+                    .HasDefaultValueSql("gen_random_uuid()");
+
+                b.Property<Guid>("OrdemServicoId")
+                    .HasColumnType("uuid");
+
+                b.Property<Guid?>("PecaId")
+                    .HasColumnType("uuid");
+
+                b.Property<decimal>("Preco")
+                    .HasColumnType("numeric(12,2)");
+
+                b.Property<decimal>("Quantidade")
+                    .HasColumnType("numeric(12,3)");
+
+                b.Property<Guid?>("ServicoId")
+                    .HasColumnType("uuid");
+
+                b.Property<string>("Tipo")
+                    .IsRequired()
+                    .HasMaxLength(20)
+                    .HasColumnType("character varying(20)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("OrdemServicoId");
+
+                b.HasIndex("PecaId");
+
+                b.HasIndex("ServicoId");
+
+                b.ToTable("itens_ordem_servico", "oficina");
+            });
+
             modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.Moto", b =>
             {
                 b.Property<Guid>("Id")
@@ -111,6 +149,49 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
                     .HasDatabaseName("IX_motos_placa");
 
                 b.ToTable("motos", "oficina");
+            });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.OrdemServico", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uuid")
+                    .HasDefaultValueSql("gen_random_uuid()");
+
+                b.Property<Guid>("ClienteId")
+                    .HasColumnType("uuid");
+
+                b.Property<DateTime>("DataAbertura")
+                    .HasColumnType("timestamp with time zone");
+
+                b.Property<DateTime?>("DataFechamento")
+                    .HasColumnType("timestamp with time zone");
+
+                b.Property<Guid>("MotoId")
+                    .HasColumnType("uuid");
+
+                b.Property<Guid>("ProfissionalId")
+                    .HasColumnType("uuid");
+
+                b.Property<string>("Status")
+                    .IsRequired()
+                    .HasMaxLength(40)
+                    .HasColumnType("character varying(40)");
+
+                b.Property<decimal>("Total")
+                    .HasColumnType("numeric(12,2)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("ClienteId");
+
+                b.HasIndex("MotoId");
+
+                b.HasIndex("ProfissionalId");
+
+                b.HasIndex("DataAbertura", "Status");
+
+                b.ToTable("ordens_servico", "oficina");
             });
 
             modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.Peca", b =>
@@ -191,6 +272,63 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
                     .IsRequired();
 
                 b.Navigation("Cliente");
+            });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.ItemOrdemServico", b =>
+            {
+                b.HasOne("Oficina.Cadastro.Domain.Entities.OrdemServico", "OrdemServico")
+                    .WithMany("Itens")
+                    .HasForeignKey("OrdemServicoId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Oficina.Cadastro.Domain.Entities.Peca", "Peca")
+                    .WithMany()
+                    .HasForeignKey("PecaId")
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                b.HasOne("Oficina.Cadastro.Domain.Entities.Servico", "Servico")
+                    .WithMany()
+                    .HasForeignKey("ServicoId")
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                b.Navigation("OrdemServico");
+
+                b.Navigation("Peca");
+
+                b.Navigation("Servico");
+            });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.OrdemServico", b =>
+            {
+                b.HasOne("Oficina.Cadastro.Domain.Entities.Cliente", "Cliente")
+                    .WithMany()
+                    .HasForeignKey("ClienteId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Oficina.Cadastro.Domain.Entities.Moto", "Moto")
+                    .WithMany()
+                    .HasForeignKey("MotoId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("Oficina.Cadastro.Domain.Entities.Profissional", "Profissional")
+                    .WithMany()
+                    .HasForeignKey("ProfissionalId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Cliente");
+
+                b.Navigation("Moto");
+
+                b.Navigation("Profissional");
+            });
+
+            modelBuilder.Entity("Oficina.Cadastro.Domain.Entities.OrdemServico", b =>
+            {
+                b.Navigation("Itens");
             });
 #pragma warning restore 612, 618
         }

--- a/Oficina.Cadastro.Infrastructure/Persistence/CadastroDbContext.cs
+++ b/Oficina.Cadastro.Infrastructure/Persistence/CadastroDbContext.cs
@@ -15,6 +15,8 @@ public class CadastroDbContext : DbContext
     public DbSet<Profissional> Profissionais => Set<Profissional>();
     public DbSet<Servico> Servicos => Set<Servico>();
     public DbSet<Peca> Pecas => Set<Peca>();
+    public DbSet<OrdemServico> OrdensServico => Set<OrdemServico>();
+    public DbSet<ItemOrdemServico> ItensOrdemServico => Set<ItemOrdemServico>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -26,6 +28,8 @@ public class CadastroDbContext : DbContext
         modelBuilder.ApplyConfiguration(new ProfissionalConfiguration());
         modelBuilder.ApplyConfiguration(new ServicoConfiguration());
         modelBuilder.ApplyConfiguration(new PecaConfiguration());
+        modelBuilder.ApplyConfiguration(new OrdemServicoConfiguration());
+        modelBuilder.ApplyConfiguration(new ItemOrdemServicoConfiguration());
 
         base.OnModelCreating(modelBuilder);
     }

--- a/Oficina.Cadastro.Infrastructure/Persistence/Configurations/ItemOrdemServicoConfiguration.cs
+++ b/Oficina.Cadastro.Infrastructure/Persistence/Configurations/ItemOrdemServicoConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Oficina.Cadastro.Domain.Entities;
+using Oficina.Cadastro.Infrastructure.Persistence;
 
 namespace Oficina.Cadastro.Infrastructure.Persistence.Configurations;
 
@@ -8,7 +9,7 @@ public class ItemOrdemServicoConfiguration : IEntityTypeConfiguration<ItemOrdemS
 {
     public void Configure(EntityTypeBuilder<ItemOrdemServico> builder)
     {
-        builder.ToTable("itens_ordem_servico");
+        builder.ToTable("itens_ordem_servico", CadastroDbContext.Schema);
 
         builder.HasKey(x => x.Id);
 

--- a/Oficina.Cadastro.Infrastructure/Persistence/Configurations/OrdemServicoConfiguration.cs
+++ b/Oficina.Cadastro.Infrastructure/Persistence/Configurations/OrdemServicoConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Oficina.Cadastro.Domain.Entities;
+using Oficina.Cadastro.Infrastructure.Persistence;
 
 namespace Oficina.Cadastro.Infrastructure.Persistence.Configurations;
 
@@ -8,7 +9,7 @@ public class OrdemServicoConfiguration : IEntityTypeConfiguration<OrdemServico>
 {
     public void Configure(EntityTypeBuilder<OrdemServico> builder)
     {
-        builder.ToTable("ordens_servico");
+        builder.ToTable("ordens_servico", CadastroDbContext.Schema);
 
         builder.HasKey(x => x.Id);
 


### PR DESCRIPTION
## Summary
- expose the OrdemServico and ItemOrdemServico sets and configurations in the Cadastro DbContext
- update the initial migration and model snapshot to create the service order tables with all indexes and relationships
- align the configuration classes to use the shared schema constant for the new tables

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dafbd418b48327a4d0ef7bae4911e0