### PR TITLE
Improve connection string resolution for local development

### DIFF
--- a/Oficina.ApiGateway/Program.cs
+++ b/Oficina.ApiGateway/Program.cs
@@ -1,15 +1,23 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Oficina.Cadastro.Endpoints;
 using Oficina.Cadastro.Infrastructure.Persistence;
 
 var builder = WebApplication.CreateBuilder(args);
 
-//Conn string via env var "ConnectionStrings__Default"
-var connectionString = builder.Configuration.GetConnectionString("OficinaDb") ?? builder.Configuration["ConnectionStrings:OficinaDb"];
-builder.Services.AddDbContext<CadastroDbContext>(opt => opt.UseNpgsql(connectionString));
+//Conn string via env var "ConnectionStrings__OficinaDb" ou "ConnectionStrings__Default"
+var connectionString = builder.Configuration.GetConnectionString("OficinaDb")
+                      ?? builder.Configuration["ConnectionStrings:OficinaDb"]
+                      ?? builder.Configuration.GetConnectionString("Default")
+                      ?? builder.Configuration["ConnectionStrings:Default"];
+
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    throw new InvalidOperationException("Connection string 'OficinaDb' was not found.");
+}
 
 builder.Services.AddDbContext<CadastroDbContext>(opt =>
-    opt.UseNpgsql(builder.Configuration.GetConnectionString("OficinaDb"),
+    opt.UseNpgsql(connectionString,
     sql => sql.MigrationsAssembly(typeof(CadastroDbContext).Assembly.FullName))
 );
 

--- a/Oficina.ApiGateway/appsettings.Development.json
+++ b/Oficina.ApiGateway/appsettings.Development.json
@@ -1,4 +1,8 @@
 {
+  "ConnectionStrings": {
+    "OficinaDb": "Host=localhost;Port=5432;Database=oficina_db;Username=oficina;Password=oficina123",
+    "Default": "Host=localhost;Port=5432;Database=oficina_db;Username=oficina;Password=oficina123"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- ensure the API resolves either the `OficinaDb` or `Default` connection string before configuring the DbContext
- add localhost connection strings to the development configuration for easier local database connectivity

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc27a784f48327933960578f3d7223