### PR TITLE
feat: expand cadastro cliente domain schema

### DIFF
--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/Cliente.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/Cliente.cs
@@ -1,9 +1,24 @@
+using System;
+using System.Collections.Generic;
 using Oficina.SharedKernel.Domain;
+
 namespace Oficina.Cadastro.Domain;
+
 public class Cliente : Entity
 {
     public string Nome { get; set; } = default!;
     public string Documento { get; set; } = default!;
     public string Telefone { get; set; } = default!;
     public string Email { get; set; } = default!;
+    public Guid? Origem_Id { get; set; }
+    public ClienteOrigem? Origem { get; set; }
+    public PessoaPf? PessoaPf { get; set; }
+    public PessoaPj? PessoaPj { get; set; }
+    public ClienteLgpdConsentimento? LgpdConsentimento { get; set; }
+    public ClienteFinanceiro? Financeiro { get; set; }
+    public ICollection<ClienteEndereco> Enderecos { get; set; } = new List<ClienteEndereco>();
+    public ICollection<ClienteContato> Contatos { get; set; } = new List<ClienteContato>();
+    public ICollection<ClienteIndicacao> Indicacoes { get; set; } = new List<ClienteIndicacao>();
+    public ICollection<Veiculo> Veiculos { get; set; } = new List<Veiculo>();
+    public ICollection<ClienteAnexo> Anexos { get; set; } = new List<ClienteAnexo>();
 }

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteAnexo.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteAnexo.cs
@@ -1,0 +1,14 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class ClienteAnexo : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public string Nome_Arquivo { get; set; } = default!;
+    public string Tipo_Conteudo { get; set; } = default!;
+    public string Caminho_Arquivo { get; set; } = default!;
+    public string? Observacao { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteContato.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteContato.cs
@@ -1,0 +1,14 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class ClienteContato : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public string Tipo { get; set; } = "Telefone";
+    public string Valor { get; set; } = default!;
+    public string? Observacao { get; set; }
+    public bool Principal { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteEndereco.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteEndereco.cs
@@ -1,0 +1,20 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class ClienteEndereco : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public string Tipo { get; set; } = "Residencial";
+    public string Logradouro { get; set; } = default!;
+    public string Numero { get; set; } = default!;
+    public string? Complemento { get; set; }
+    public string Bairro { get; set; } = default!;
+    public string Cidade { get; set; } = default!;
+    public string Estado { get; set; } = default!;
+    public string Cep { get; set; } = default!;
+    public string? Pais { get; set; }
+    public bool Principal { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteFinanceiro.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteFinanceiro.cs
@@ -1,0 +1,14 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class ClienteFinanceiro : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public decimal Limite_Credito { get; set; }
+    public int? Prazo_Pagamento { get; set; }
+    public bool Bloqueado { get; set; }
+    public string? Observacoes { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteIndicacao.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteIndicacao.cs
@@ -1,0 +1,13 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class ClienteIndicacao : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public string Indicador_Nome { get; set; } = default!;
+    public string? Indicador_Telefone { get; set; }
+    public string? Observacao { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteLgpdConsentimento.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteLgpdConsentimento.cs
@@ -1,0 +1,14 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class ClienteLgpdConsentimento : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public bool Aceito { get; set; }
+    public DateTime Data_Consentimento { get; set; }
+    public string Canal { get; set; } = default!;
+    public string? Observacao { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteOrigem.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/ClienteOrigem.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class ClienteOrigem : Entity
+{
+    public string Nome { get; set; } = default!;
+    public string? Descricao { get; set; }
+    public ICollection<Cliente> Clientes { get; set; } = new List<Cliente>();
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/PessoaPf.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/PessoaPf.cs
@@ -1,0 +1,16 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class PessoaPf : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public string Cpf { get; set; } = default!;
+    public string? Rg { get; set; }
+    public DateTime? Data_Nascimento { get; set; }
+    public string? Genero { get; set; }
+    public string? Estado_Civil { get; set; }
+    public string? Profissao { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/PessoaPj.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/PessoaPj.cs
@@ -1,0 +1,15 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class PessoaPj : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public string Razao_Social { get; set; } = default!;
+    public string Nome_Fantasia { get; set; } = default!;
+    public string Cnpj { get; set; } = default!;
+    public string? Inscricao_Estadual { get; set; }
+    public string? Inscricao_Municipal { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/Veiculo.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/Veiculo.cs
@@ -1,0 +1,20 @@
+using System;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class Veiculo : Entity
+{
+    public Guid Cliente_Id { get; set; }
+    public Cliente Cliente { get; set; } = default!;
+    public Guid Modelo_Id { get; set; }
+    public VeiculoModelo Modelo { get; set; } = default!;
+    public string Placa { get; set; } = default!;
+    public int? Ano_Fabricacao { get; set; }
+    public int? Ano_Modelo { get; set; }
+    public string? Cor { get; set; }
+    public string? Renavam { get; set; }
+    public string? Chassi { get; set; }
+    public string? Combustivel { get; set; }
+    public string? Observacao { get; set; }
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/VeiculoMarca.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/VeiculoMarca.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class VeiculoMarca : Entity
+{
+    public string Nome { get; set; } = default!;
+    public string? Pais { get; set; }
+    public ICollection<VeiculoModelo> Modelos { get; set; } = new List<VeiculoModelo>();
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/VeiculoModelo.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Domain/VeiculoModelo.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using Oficina.SharedKernel.Domain;
+
+namespace Oficina.Cadastro.Domain;
+
+public class VeiculoModelo : Entity
+{
+    public Guid Marca_Id { get; set; }
+    public VeiculoMarca Marca { get; set; } = default!;
+    public string Nome { get; set; } = default!;
+    public int? Ano_Inicio { get; set; }
+    public int? Ano_Fim { get; set; }
+    public ICollection<Veiculo> Veiculos { get; set; } = new List<Veiculo>();
+}

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Infrastructure/DbContext.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Infrastructure/DbContext.cs
@@ -1,29 +1,224 @@
 using Microsoft.EntityFrameworkCore;
 using Oficina.Cadastro.Domain;
+
 namespace Oficina.Cadastro.Infrastructure;
+
 public class CadastroDbContext : DbContext
 {
     public CadastroDbContext(DbContextOptions<CadastroDbContext> options) : base(options) { }
+
     public DbSet<Cliente> Clientes => Set<Cliente>();
+    public DbSet<ClienteOrigem> ClienteOrigens => Set<ClienteOrigem>();
+    public DbSet<PessoaPf> PessoasPf => Set<PessoaPf>();
+    public DbSet<PessoaPj> PessoasPj => Set<PessoaPj>();
+    public DbSet<ClienteEndereco> ClienteEnderecos => Set<ClienteEndereco>();
+    public DbSet<ClienteContato> ClienteContatos => Set<ClienteContato>();
+    public DbSet<ClienteIndicacao> ClienteIndicacoes => Set<ClienteIndicacao>();
+    public DbSet<ClienteLgpdConsentimento> ClienteLgpdConsentimentos => Set<ClienteLgpdConsentimento>();
+    public DbSet<ClienteFinanceiro> ClienteFinanceiro => Set<ClienteFinanceiro>();
+    public DbSet<VeiculoMarca> VeiculoMarcas => Set<VeiculoMarca>();
+    public DbSet<VeiculoModelo> VeiculoModelos => Set<VeiculoModelo>();
+    public DbSet<Veiculo> Veiculos => Set<Veiculo>();
+    public DbSet<ClienteAnexo> ClienteAnexos => Set<ClienteAnexo>();
     public DbSet<Mecanico> Mecanicos => Set<Mecanico>();
     public DbSet<Fornecedor> Fornecedores => Set<Fornecedor>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<Cliente>(e=>{
-            e.ToTable("cad_clientes");
-            e.Property(p=>p.Nome).HasMaxLength(120).IsRequired();
-            e.Property(p=>p.Documento).HasMaxLength(20).IsRequired();
-            e.HasIndex(p=>p.Documento).IsUnique();
+        modelBuilder.Entity<Cliente>(entity =>
+        {
+            entity.ToTable("cad_clientes");
+            entity.Property(p => p.Nome).HasMaxLength(160).IsRequired();
+            entity.Property(p => p.Documento).HasMaxLength(20).IsRequired();
+            entity.Property(p => p.Telefone).HasMaxLength(20);
+            entity.Property(p => p.Email).HasMaxLength(160);
+            entity.HasIndex(p => p.Documento).IsUnique();
+            entity.HasOne(p => p.Origem)
+                .WithMany(o => o.Clientes)
+                .HasForeignKey(p => p.Origem_Id)
+                .OnDelete(DeleteBehavior.SetNull);
+            entity.HasMany(p => p.Enderecos)
+                .WithOne(e => e.Cliente)
+                .HasForeignKey(e => e.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(p => p.Contatos)
+                .WithOne(e => e.Cliente)
+                .HasForeignKey(e => e.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(p => p.Indicacoes)
+                .WithOne(e => e.Cliente)
+                .HasForeignKey(e => e.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(p => p.Veiculos)
+                .WithOne(e => e.Cliente)
+                .HasForeignKey(e => e.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(p => p.Anexos)
+                .WithOne(e => e.Cliente)
+                .HasForeignKey(e => e.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
         });
-        modelBuilder.Entity<Mecanico>(e=>{
-            e.ToTable("cad_mecanicos");
-            e.Property(p=>p.Nome).HasMaxLength(120).IsRequired();
+
+        modelBuilder.Entity<ClienteOrigem>(entity =>
+        {
+            entity.ToTable("cad_clientes_origens");
+            entity.Property(p => p.Nome).HasMaxLength(120).IsRequired();
+            entity.Property(p => p.Descricao).HasMaxLength(240);
+            entity.HasIndex(p => p.Nome).IsUnique();
         });
-        modelBuilder.Entity<Fornecedor>(e=>{
-            e.ToTable("cad_fornecedores");
-            e.Property(p=>p.Razao_Social).HasMaxLength(160).IsRequired();
-            e.Property(p=>p.Cnpj).HasMaxLength(20).IsRequired();
-            e.HasIndex(p=>p.Cnpj).IsUnique();
+
+        modelBuilder.Entity<PessoaPf>(entity =>
+        {
+            entity.ToTable("cad_clientes_pf");
+            entity.Property(p => p.Cpf).HasMaxLength(14).IsRequired();
+            entity.Property(p => p.Rg).HasMaxLength(20);
+            entity.Property(p => p.Genero).HasMaxLength(20);
+            entity.Property(p => p.Estado_Civil).HasMaxLength(20);
+            entity.Property(p => p.Profissao).HasMaxLength(120);
+            entity.HasIndex(p => p.Cpf).IsUnique();
+            entity.HasIndex(p => p.Cliente_Id).IsUnique();
+            entity.HasOne(p => p.Cliente)
+                .WithOne(c => c.PessoaPf)
+                .HasForeignKey<PessoaPf>(p => p.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<PessoaPj>(entity =>
+        {
+            entity.ToTable("cad_clientes_pj");
+            entity.Property(p => p.Razao_Social).HasMaxLength(200).IsRequired();
+            entity.Property(p => p.Nome_Fantasia).HasMaxLength(200).IsRequired();
+            entity.Property(p => p.Cnpj).HasMaxLength(18).IsRequired();
+            entity.Property(p => p.Inscricao_Estadual).HasMaxLength(30);
+            entity.Property(p => p.Inscricao_Municipal).HasMaxLength(30);
+            entity.HasIndex(p => p.Cnpj).IsUnique();
+            entity.HasIndex(p => p.Cliente_Id).IsUnique();
+            entity.HasOne(p => p.Cliente)
+                .WithOne(c => c.PessoaPj)
+                .HasForeignKey<PessoaPj>(p => p.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<ClienteEndereco>(entity =>
+        {
+            entity.ToTable("cad_clientes_enderecos");
+            entity.Property(p => p.Tipo).HasMaxLength(40).IsRequired();
+            entity.Property(p => p.Logradouro).HasMaxLength(160).IsRequired();
+            entity.Property(p => p.Numero).HasMaxLength(20).IsRequired();
+            entity.Property(p => p.Complemento).HasMaxLength(120);
+            entity.Property(p => p.Bairro).HasMaxLength(120).IsRequired();
+            entity.Property(p => p.Cidade).HasMaxLength(120).IsRequired();
+            entity.Property(p => p.Estado).HasMaxLength(60).IsRequired();
+            entity.Property(p => p.Cep).HasMaxLength(12).IsRequired();
+            entity.Property(p => p.Pais).HasMaxLength(80);
+            entity.Property(p => p.Principal).HasDefaultValue(false);
+            entity.HasIndex(p => new { p.Cliente_Id, p.Tipo, p.Principal });
+        });
+
+        modelBuilder.Entity<ClienteContato>(entity =>
+        {
+            entity.ToTable("cad_clientes_contatos");
+            entity.Property(p => p.Tipo).HasMaxLength(40).IsRequired();
+            entity.Property(p => p.Valor).HasMaxLength(160).IsRequired();
+            entity.Property(p => p.Observacao).HasMaxLength(240);
+            entity.Property(p => p.Principal).HasDefaultValue(false);
+            entity.HasIndex(p => new { p.Cliente_Id, p.Tipo, p.Valor }).IsUnique();
+        });
+
+        modelBuilder.Entity<ClienteIndicacao>(entity =>
+        {
+            entity.ToTable("cad_clientes_indicacoes");
+            entity.Property(p => p.Indicador_Nome).HasMaxLength(160).IsRequired();
+            entity.Property(p => p.Indicador_Telefone).HasMaxLength(20);
+            entity.Property(p => p.Observacao).HasMaxLength(240);
+            entity.HasIndex(p => p.Cliente_Id);
+        });
+
+        modelBuilder.Entity<ClienteLgpdConsentimento>(entity =>
+        {
+            entity.ToTable("cad_clientes_lgpd_consentimentos");
+            entity.Property(p => p.Canal).HasMaxLength(80).IsRequired();
+            entity.Property(p => p.Observacao).HasMaxLength(240);
+            entity.HasIndex(p => p.Cliente_Id).IsUnique();
+            entity.HasOne(p => p.Cliente)
+                .WithOne(c => c.LgpdConsentimento)
+                .HasForeignKey<ClienteLgpdConsentimento>(p => p.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<ClienteFinanceiro>(entity =>
+        {
+            entity.ToTable("cad_clientes_financeiro");
+            entity.Property(p => p.Limite_Credito).HasColumnType("decimal(10,2)");
+            entity.Property(p => p.Observacoes).HasMaxLength(500);
+            entity.HasIndex(p => p.Cliente_Id).IsUnique();
+            entity.HasOne(p => p.Cliente)
+                .WithOne(c => c.Financeiro)
+                .HasForeignKey<ClienteFinanceiro>(p => p.Cliente_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<VeiculoMarca>(entity =>
+        {
+            entity.ToTable("cad_veiculos_marcas");
+            entity.Property(p => p.Nome).HasMaxLength(120).IsRequired();
+            entity.Property(p => p.Pais).HasMaxLength(80);
+            entity.HasIndex(p => p.Nome).IsUnique();
+        });
+
+        modelBuilder.Entity<VeiculoModelo>(entity =>
+        {
+            entity.ToTable("cad_veiculos_modelos");
+            entity.Property(p => p.Nome).HasMaxLength(160).IsRequired();
+            entity.HasIndex(p => new { p.Marca_Id, p.Nome }).IsUnique();
+            entity.HasOne(p => p.Marca)
+                .WithMany(m => m.Modelos)
+                .HasForeignKey(p => p.Marca_Id)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Veiculo>(entity =>
+        {
+            entity.ToTable("cad_veiculos");
+            entity.Property(p => p.Placa).HasMaxLength(10).IsRequired();
+            entity.Property(p => p.Cor).HasMaxLength(40);
+            entity.Property(p => p.Renavam).HasMaxLength(20);
+            entity.Property(p => p.Chassi).HasMaxLength(40);
+            entity.Property(p => p.Combustivel).HasMaxLength(40);
+            entity.Property(p => p.Observacao).HasMaxLength(240);
+            entity.HasIndex(p => p.Placa).IsUnique();
+            entity.HasIndex(p => p.Renavam)
+                .IsUnique()
+                .HasFilter("[Renavam] IS NOT NULL");
+            entity.HasOne(p => p.Modelo)
+                .WithMany(m => m.Veiculos)
+                .HasForeignKey(p => p.Modelo_Id)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<ClienteAnexo>(entity =>
+        {
+            entity.ToTable("cad_clientes_anexos");
+            entity.Property(p => p.Nome_Arquivo).HasMaxLength(200).IsRequired();
+            entity.Property(p => p.Tipo_Conteudo).HasMaxLength(100).IsRequired();
+            entity.Property(p => p.Caminho_Arquivo).HasMaxLength(500).IsRequired();
+            entity.Property(p => p.Observacao).HasMaxLength(240);
+            entity.HasIndex(p => new { p.Cliente_Id, p.Nome_Arquivo }).IsUnique();
+        });
+
+        modelBuilder.Entity<Mecanico>(entity =>
+        {
+            entity.ToTable("cad_mecanicos");
+            entity.Property(p => p.Nome).HasMaxLength(120).IsRequired();
+        });
+
+        modelBuilder.Entity<Fornecedor>(entity =>
+        {
+            entity.ToTable("cad_fornecedores");
+            entity.Property(p => p.Razao_Social).HasMaxLength(160).IsRequired();
+            entity.Property(p => p.Cnpj).HasMaxLength(20).IsRequired();
+            entity.Property(p => p.Contato).HasMaxLength(160).IsRequired();
+            entity.HasIndex(p => p.Cnpj).IsUnique();
         });
     }
 }

--- a/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Infrastructure/Migrations/202409300001_Initial.cs
+++ b/src/Oficina.Modules/Cadastro/Oficina.Cadastro/Infrastructure/Migrations/202409300001_Initial.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
+
 #nullable disable
+
 namespace Oficina.Cadastro.Infrastructure.Migrations
 {
     public partial class Initial : Migration
@@ -7,47 +9,512 @@ namespace Oficina.Cadastro.Infrastructure.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
+                name: "cad_clientes_origens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Nome = table.Column<string>(maxLength: 120, nullable: false),
+                    Descricao = table.Column<string>(maxLength: 240, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_origens", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "cad_clientes",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(nullable:false),
-                    CreatedAt = table.Column<DateTime>(nullable:false),
-                    UpdatedAt = table.Column<DateTime>(nullable:true),
-                    Nome = table.Column<string>(maxLength:120, nullable:false),
-                    Documento = table.Column<string>(maxLength:20, nullable:false),
-                    Telefone = table.Column<string>(nullable:false),
-                    Email = table.Column<string>(nullable:false)
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Nome = table.Column<string>(maxLength: 160, nullable: false),
+                    Documento = table.Column<string>(maxLength: 20, nullable: false),
+                    Telefone = table.Column<string>(maxLength: 20, nullable: false),
+                    Email = table.Column<string>(maxLength: 160, nullable: false),
+                    Origem_Id = table.Column<Guid>(nullable: true)
                 },
-                constraints: table => { table.PrimaryKey("PK_cad_clientes", x => x.Id); });
-            migrationBuilder.CreateIndex(name:"IX_cad_clientes_Documento", table:"cad_clientes", column:"Documento", unique:true);
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_cad_clientes_origens_Origem_Id",
+                        column: x => x.Origem_Id,
+                        principalTable: "cad_clientes_origens",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
 
             migrationBuilder.CreateTable(
-                name: "cad_mecanicos",
+                name: "cad_clientes_pf",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(nullable:false),
-                    CreatedAt = table.Column<DateTime>(nullable:false),
-                    UpdatedAt = table.Column<DateTime>(nullable:true),
-                    Nome = table.Column<string>(maxLength:120, nullable:false),
-                    Especialidade = table.Column<string>(nullable:false),
-                    Ativo = table.Column<bool>(nullable:false)
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Cpf = table.Column<string>(maxLength: 14, nullable: false),
+                    Rg = table.Column<string>(maxLength: 20, nullable: true),
+                    Data_Nascimento = table.Column<DateTime>(nullable: true),
+                    Genero = table.Column<string>(maxLength: 20, nullable: true),
+                    Estado_Civil = table.Column<string>(maxLength: 20, nullable: true),
+                    Profissao = table.Column<string>(maxLength: 120, nullable: true)
                 },
-                constraints: table => { table.PrimaryKey("PK_cad_mecanicos", x => x.Id); });
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_pf", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_pf_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_clientes_pj",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Razao_Social = table.Column<string>(maxLength: 200, nullable: false),
+                    Nome_Fantasia = table.Column<string>(maxLength: 200, nullable: false),
+                    Cnpj = table.Column<string>(maxLength: 18, nullable: false),
+                    Inscricao_Estadual = table.Column<string>(maxLength: 30, nullable: true),
+                    Inscricao_Municipal = table.Column<string>(maxLength: 30, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_pj", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_pj_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_clientes_financeiro",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Limite_Credito = table.Column<decimal>(type: "decimal(10,2)", nullable: false),
+                    Prazo_Pagamento = table.Column<int>(nullable: true),
+                    Bloqueado = table.Column<bool>(nullable: false),
+                    Observacoes = table.Column<string>(maxLength: 500, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_financeiro", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_financeiro_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_clientes_lgpd_consentimentos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Aceito = table.Column<bool>(nullable: false),
+                    Data_Consentimento = table.Column<DateTime>(nullable: false),
+                    Canal = table.Column<string>(maxLength: 80, nullable: false),
+                    Observacao = table.Column<string>(maxLength: 240, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_lgpd_consentimentos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_lgpd_consentimentos_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_clientes_anexos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Nome_Arquivo = table.Column<string>(maxLength: 200, nullable: false),
+                    Tipo_Conteudo = table.Column<string>(maxLength: 100, nullable: false),
+                    Caminho_Arquivo = table.Column<string>(maxLength: 500, nullable: false),
+                    Observacao = table.Column<string>(maxLength: 240, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_anexos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_anexos_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_clientes_contatos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Tipo = table.Column<string>(maxLength: 40, nullable: false),
+                    Valor = table.Column<string>(maxLength: 160, nullable: false),
+                    Observacao = table.Column<string>(maxLength: 240, nullable: true),
+                    Principal = table.Column<bool>(nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_contatos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_contatos_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_clientes_enderecos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Tipo = table.Column<string>(maxLength: 40, nullable: false),
+                    Logradouro = table.Column<string>(maxLength: 160, nullable: false),
+                    Numero = table.Column<string>(maxLength: 20, nullable: false),
+                    Complemento = table.Column<string>(maxLength: 120, nullable: true),
+                    Bairro = table.Column<string>(maxLength: 120, nullable: false),
+                    Cidade = table.Column<string>(maxLength: 120, nullable: false),
+                    Estado = table.Column<string>(maxLength: 60, nullable: false),
+                    Cep = table.Column<string>(maxLength: 12, nullable: false),
+                    Pais = table.Column<string>(maxLength: 80, nullable: true),
+                    Principal = table.Column<bool>(nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_enderecos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_enderecos_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_clientes_indicacoes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Indicador_Nome = table.Column<string>(maxLength: 160, nullable: false),
+                    Indicador_Telefone = table.Column<string>(maxLength: 20, nullable: true),
+                    Observacao = table.Column<string>(maxLength: 240, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_clientes_indicacoes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_clientes_indicacoes_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_veiculos_marcas",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Nome = table.Column<string>(maxLength: 120, nullable: false),
+                    Pais = table.Column<string>(maxLength: 80, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_veiculos_marcas", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_veiculos_modelos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Marca_Id = table.Column<Guid>(nullable: false),
+                    Nome = table.Column<string>(maxLength: 160, nullable: false),
+                    Ano_Inicio = table.Column<int>(nullable: true),
+                    Ano_Fim = table.Column<int>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_veiculos_modelos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_veiculos_modelos_cad_veiculos_marcas_Marca_Id",
+                        column: x => x.Marca_Id,
+                        principalTable: "cad_veiculos_marcas",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_veiculos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Cliente_Id = table.Column<Guid>(nullable: false),
+                    Modelo_Id = table.Column<Guid>(nullable: false),
+                    Placa = table.Column<string>(maxLength: 10, nullable: false),
+                    Ano_Fabricacao = table.Column<int>(nullable: true),
+                    Ano_Modelo = table.Column<int>(nullable: true),
+                    Cor = table.Column<string>(maxLength: 40, nullable: true),
+                    Renavam = table.Column<string>(maxLength: 20, nullable: true),
+                    Chassi = table.Column<string>(maxLength: 40, nullable: true),
+                    Combustivel = table.Column<string>(maxLength: 40, nullable: true),
+                    Observacao = table.Column<string>(maxLength: 240, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_veiculos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_cad_veiculos_cad_clientes_Cliente_Id",
+                        column: x => x.Cliente_Id,
+                        principalTable: "cad_clientes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_cad_veiculos_cad_veiculos_modelos_Modelo_Id",
+                        column: x => x.Modelo_Id,
+                        principalTable: "cad_veiculos_modelos",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
 
             migrationBuilder.CreateTable(
                 name: "cad_fornecedores",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(nullable:false),
-                    CreatedAt = table.Column<DateTime>(nullable:false),
-                    UpdatedAt = table.Column<DateTime>(nullable:true),
-                    RazaoSocial = table.Column<string>(maxLength:160, nullable:false),
-                    Cnpj = table.Column<string>(maxLength:20, nullable:false),
-                    Contato = table.Column<string>(nullable:false)
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Razao_Social = table.Column<string>(maxLength: 160, nullable: false),
+                    Cnpj = table.Column<string>(maxLength: 20, nullable: false),
+                    Contato = table.Column<string>(maxLength: 160, nullable: false)
                 },
-                constraints: table => { table.PrimaryKey("PK_cad_fornecedores", x => x.Id); });
-            migrationBuilder.CreateIndex(name:"IX_cad_fornecedores_Cnpj", table:"cad_fornecedores", column:"Cnpj", unique:true);
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_fornecedores", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "cad_mecanicos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created_At = table.Column<DateTime>(nullable: false),
+                    Updated_At = table.Column<DateTime>(nullable: true),
+                    Nome = table.Column<string>(maxLength: 120, nullable: false),
+                    Especialidade = table.Column<string>(nullable: false),
+                    Ativo = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cad_mecanicos", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_Documento",
+                table: "cad_clientes",
+                column: "Documento",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_Origem_Id",
+                table: "cad_clientes",
+                column: "Origem_Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_anexos_Cliente_Id_Nome_Arquivo",
+                table: "cad_clientes_anexos",
+                columns: new[] { "Cliente_Id", "Nome_Arquivo" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_contatos_Cliente_Id_Tipo_Valor",
+                table: "cad_clientes_contatos",
+                columns: new[] { "Cliente_Id", "Tipo", "Valor" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_enderecos_Cliente_Id_Tipo_Principal",
+                table: "cad_clientes_enderecos",
+                columns: new[] { "Cliente_Id", "Tipo", "Principal" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_financeiro_Cliente_Id",
+                table: "cad_clientes_financeiro",
+                column: "Cliente_Id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_indicacoes_Cliente_Id",
+                table: "cad_clientes_indicacoes",
+                column: "Cliente_Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_lgpd_consentimentos_Cliente_Id",
+                table: "cad_clientes_lgpd_consentimentos",
+                column: "Cliente_Id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_origens_Nome",
+                table: "cad_clientes_origens",
+                column: "Nome",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_pf_Cliente_Id",
+                table: "cad_clientes_pf",
+                column: "Cliente_Id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_pf_Cpf",
+                table: "cad_clientes_pf",
+                column: "Cpf",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_pj_Cliente_Id",
+                table: "cad_clientes_pj",
+                column: "Cliente_Id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_clientes_pj_Cnpj",
+                table: "cad_clientes_pj",
+                column: "Cnpj",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_fornecedores_Cnpj",
+                table: "cad_fornecedores",
+                column: "Cnpj",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_veiculos_Cliente_Id",
+                table: "cad_veiculos",
+                column: "Cliente_Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_veiculos_Modelo_Id",
+                table: "cad_veiculos",
+                column: "Modelo_Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_veiculos_Placa",
+                table: "cad_veiculos",
+                column: "Placa",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_veiculos_Renavam",
+                table: "cad_veiculos",
+                column: "Renavam",
+                unique: true,
+                filter: "[Renavam] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_veiculos_marcas_Nome",
+                table: "cad_veiculos_marcas",
+                column: "Nome",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cad_veiculos_modelos_Marca_Id_Nome",
+                table: "cad_veiculos_modelos",
+                columns: new[] { "Marca_Id", "Nome" },
+                unique: true);
         }
-        protected override void Down(MigrationBuilder migrationBuilder) { }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "cad_clientes_anexos");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes_contatos");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes_enderecos");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes_financeiro");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes_indicacoes");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes_lgpd_consentimentos");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes_pf");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes_pj");
+
+            migrationBuilder.DropTable(
+                name: "cad_fornecedores");
+
+            migrationBuilder.DropTable(
+                name: "cad_mecanicos");
+
+            migrationBuilder.DropTable(
+                name: "cad_veiculos");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes");
+
+            migrationBuilder.DropTable(
+                name: "cad_veiculos_modelos");
+
+            migrationBuilder.DropTable(
+                name: "cad_clientes_origens");
+
+            migrationBuilder.DropTable(
+                name: "cad_veiculos_marcas");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend the cadastro domain with origin, person, contact, address, attachment, vehicle, LGPD and finance entities related to Cliente
- wire the new entities into `CadastroDbContext` with DbSets, relationships, indexes and filtered uniques
- update the initial migration so all new tables, foreign keys and indexes are created with the expected constraints

## Testing
- dotnet build oficina.sln *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df28fff5308327985b5872621f75da